### PR TITLE
Bump dependenices (esp. embedded-hal 0.2.7 -> 1.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## v0.2.0 - In Progress
 
  - Fix issue where pixels luma is never set back to 0
+ - Migrate to embedded-graphics-core 0.3 (embedded-graphics-0.7 API).
+ - Migrate examples to embedded-graphics 0.7 API.
+ - Add bounding box check
 
 ## v0.1.0 - 2020-11-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
  - Migrate to embedded-graphics-core 0.3 (embedded-graphics-0.7 API).
  - Migrate examples to embedded-graphics 0.7 API.
  - Add bounding box check
+ - Add support for different-sized displays.
 
 ## v0.1.0 - 2020-11-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
  - Migrate to embedded-graphics-core 0.3 (embedded-graphics-0.7 API).
  - Migrate examples to embedded-graphics 0.7 API.
  - Add bounding box check
- - Add support for different-sized displays.
+ - Add support for different-sized displays (128x96).
 
 ## v0.1.0 - 2020-11-25
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/daschl/ssd1327"
 
 [dependencies]
 display-interface = "0.4"
-embedded-graphics = "0.6"
+embedded-graphics-core = "0.3"
 embedded-hal = "0.2"
 
 [dev-dependencies]
@@ -20,4 +20,3 @@ rppal = { version = "0.12", features = [ "hal" ] }
 embedded-graphics = "0.6.2"
 display-interface-spi = "0.4.0"
 linux-embedded-hal = "0.3.0"
-

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,6 @@ embedded-hal = "0.2"
 
 [dev-dependencies]
 rppal = { version = "0.12", features = [ "hal" ] }
-embedded-graphics = "0.6.2"
+embedded-graphics = "0.7.1"
 display-interface-spi = "0.4.0"
 linux-embedded-hal = "0.3.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,12 +11,12 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/daschl/ssd1327"
 
 [dependencies]
-display-interface = "0.4"
-embedded-graphics-core = "0.3"
-embedded-hal = "0.2"
+display-interface = "0.5"
+embedded-graphics-core = "0.4"
+embedded-hal = "1.0.0"
 
 [dev-dependencies]
-rppal = { version = "0.12", features = [ "hal" ] }
-embedded-graphics = "0.7.1"
-display-interface-spi = "0.4.0"
-linux-embedded-hal = "0.3.0"
+rppal = { version = "0.19", features = [ "hal" ] }
+embedded-graphics = "0.8.1"
+display-interface-spi = "0.5.0"
+linux-embedded-hal = "0.4.0"

--- a/examples/raspberry_pi.rs
+++ b/examples/raspberry_pi.rs
@@ -1,10 +1,10 @@
 use {
     display_interface_spi::SPIInterface,
     embedded_graphics::{
-        fonts::{Font24x32, Text},
+        mono_font::{ascii::FONT_10X20, MonoTextStyleBuilder},
         pixelcolor::Gray4,
         prelude::*,
-        text_style,
+        text::{Baseline, Text},
     },
     linux_embedded_hal::Delay,
     rppal::{
@@ -34,13 +34,13 @@ fn main() {
     disp.clear(Gray4::new(0)).unwrap();
     disp.flush().unwrap();
 
+    let text_style = MonoTextStyleBuilder::new()
+        .font(&FONT_10X20)
+        .text_color(Gray4::new(0b0000_1111))
+        .build();
+
     // Write "Hello" to the display
-    Text::new("Hello", Point::new(0, 0))
-        .into_styled(text_style!(
-            font = Font24x32,
-            text_color = Gray4::new(0b0000_1111),
-            background_color = Gray4::new(0),
-        ))
+    Text::with_baseline("Hello", Point::zero(), text_style, Baseline::Top)
         .draw(&mut disp)
         .unwrap();
     disp.flush().unwrap();

--- a/examples/raspberry_pi.rs
+++ b/examples/raspberry_pi.rs
@@ -24,7 +24,7 @@ fn main() {
 
     // Init SPI
     let spii = SPIInterface::new(spi, dc, cs);
-    let mut disp = ssd1327::display::Ssd1327::new(spii);
+    let mut disp = ssd1327::display::Ssd1327::new(spii, ssd1327::size::DisplaySize128x128);
 
     // Reset & init
     disp.reset(&mut rst, &mut Delay).unwrap();

--- a/src/display.rs
+++ b/src/display.rs
@@ -1,11 +1,11 @@
 //! main display module
 use crate::command::Command;
 use display_interface::{DataFormat::U8, DisplayError, WriteOnlyDataCommand};
-use embedded_graphics::{
-    drawable::Pixel,
+use embedded_graphics_core::{
+    draw_target::DrawTarget,
+    geometry::{OriginDimensions, Size},
     pixelcolor::{Gray4, GrayColor},
-    prelude::Size,
-    DrawTarget,
+    Pixel,
 };
 use embedded_hal::blocking::delay::DelayMs;
 use embedded_hal::digital::v2::OutputPin;
@@ -90,18 +90,24 @@ impl<DI: WriteOnlyDataCommand> Ssd1327<DI> {
     }
 }
 
-impl<DI> DrawTarget<Gray4> for Ssd1327<DI> {
+impl<DI: WriteOnlyDataCommand> DrawTarget for Ssd1327<DI> {
+    type Color = Gray4;
     type Error = DisplayError;
 
-    fn draw_pixel(&mut self, pixel: Pixel<Gray4>) -> Result<(), Self::Error> {
-        let Pixel(point, color) = pixel;
-
-        let idx = (point.x / 2 + point.y * 64) as usize;
-        if point.x % 2 == 0 {
-            self.buffer[idx] = update_upper_half(self.buffer[idx], color.luma());
-        } else {
-            self.buffer[idx] = update_lower_half(self.buffer[idx], color.luma());
-        }
+    fn draw_iter<I>(&mut self, pixels: I) -> Result<(), Self::Error>
+    where
+        I: IntoIterator<Item = Pixel<Self::Color>>,
+    {
+        pixels
+            .into_iter()
+            .for_each(|Pixel(point, color)| {
+                let idx = (point.x / 2 + point.y * 64) as usize;
+                if point.x % 2 == 0 {
+                    self.buffer[idx] = update_upper_half(self.buffer[idx], color.luma());
+                } else {
+                    self.buffer[idx] = update_lower_half(self.buffer[idx], color.luma());
+                }
+            });
 
         Ok(())
     }
@@ -112,7 +118,12 @@ impl<DI> DrawTarget<Gray4> for Ssd1327<DI> {
         self.buffer.fill(byte);
         Ok(())
     }
+}
 
+impl<DI: WriteOnlyDataCommand> OriginDimensions for Ssd1327<DI>
+where
+    DI: WriteOnlyDataCommand,
+{
     fn size(&self) -> Size {
         Size::new(DISPLAY_WIDTH as u32, DISPLAY_HEIGHT as u32)
     }

--- a/src/display.rs
+++ b/src/display.rs
@@ -5,6 +5,7 @@ use embedded_graphics_core::{
     draw_target::DrawTarget,
     geometry::{OriginDimensions, Size},
     pixelcolor::{Gray4, GrayColor},
+    prelude::*,
     Pixel,
 };
 use embedded_hal::blocking::delay::DelayMs;
@@ -98,8 +99,11 @@ impl<DI: WriteOnlyDataCommand> DrawTarget for Ssd1327<DI> {
     where
         I: IntoIterator<Item = Pixel<Self::Color>>,
     {
+        let bb = self.bounding_box();
+
         pixels
             .into_iter()
+            .filter(|Pixel(p, _c)| bb.contains(*p))
             .for_each(|Pixel(point, color)| {
                 let idx = (point.x / 2 + point.y * 64) as usize;
                 if point.x % 2 == 0 {

--- a/src/display.rs
+++ b/src/display.rs
@@ -10,8 +10,9 @@ use embedded_graphics_core::{
     pixelcolor::{Gray4, GrayColor},
     Pixel,
 };
-use embedded_hal::blocking::delay::DelayMs;
-use embedded_hal::digital::v2::OutputPin;
+
+use embedded_hal::delay::DelayNs;
+use embedded_hal::digital::OutputPin;
 
 /// Represents the SSD1327 Display.
 ///
@@ -50,7 +51,7 @@ where
     ) -> Result<(), DisplayError>
     where
         RST: OutputPin,
-        DELAY: DelayMs<u8>,
+        DELAY: DelayNs,
     {
         rst.set_high().map_err(|_| DisplayError::BusWriteError)?;
         delay.delay_ms(100);
@@ -101,7 +102,7 @@ where
 
     /// Flushes the display, and makes the output visible on the screen.
     pub fn flush(&mut self) -> Result<(), DisplayError> {
-        self.display.send_data(U8(&self.buffer.as_mut()))
+        self.display.send_data(U8(self.buffer.as_mut()))
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,3 +6,4 @@
 
 pub mod command;
 pub mod display;
+pub mod size;

--- a/src/size.rs
+++ b/src/size.rs
@@ -1,0 +1,34 @@
+//! Display size.
+
+/// Workaround trait, since `Default` is only implemented to arrays up to 32 of size
+pub trait NewZeroed {
+    /// Creates a new value with its memory set to zero
+    fn new_zeroed() -> Self;
+}
+
+impl<const N: usize> NewZeroed for [u8; N] {
+    fn new_zeroed() -> Self {
+        [0u8; N]
+    }
+}
+
+/// Display Size and Configuration
+///
+/// This trait allows implementing various displays
+/// with different resolutions and other properties.
+pub trait DisplaySize {
+    /// Width in pixels
+    const WIDTH: u8;
+    /// Height in pixels
+    const HEIGHT: u8;
+    /// Size of framebuffer. Because the display is 4-bit grayscale, this is width * height * 4 / 8
+    type Buffer: AsMut<[u8]> + NewZeroed;
+}
+
+/// Size information for the 128x128 display
+pub struct DisplaySize128x128;
+impl DisplaySize for DisplaySize128x128 {
+    const WIDTH: u8 = 128;
+    const HEIGHT: u8 = 128;
+    type Buffer = [u8; Self::WIDTH as usize * Self::HEIGHT as usize * 4 / 8];
+}

--- a/src/size.rs
+++ b/src/size.rs
@@ -32,3 +32,11 @@ impl DisplaySize for DisplaySize128x128 {
     const HEIGHT: u8 = 128;
     type Buffer = [u8; Self::WIDTH as usize * Self::HEIGHT as usize * 4 / 8];
 }
+
+/// Size information for the 128x96 display
+pub struct DisplaySize128x96;
+impl DisplaySize for DisplaySize128x96 {
+    const WIDTH: u8 = 128;
+    const HEIGHT: u8 = 96;
+    type Buffer = [u8; Self::WIDTH as usize * Self::HEIGHT as usize * 4 / 8];
+}


### PR DESCRIPTION
This PR is based on #8 and bumps all dependencies to their current versions.
Most notably, this make the shift to embedded-hal 1., which has been released almost a year ago and is the new standard.

I have verified that it works on an rp2040 with embassy and a 128x128 OLED display from waveshare.

Let me know if there is anything that needs to be adressed before merging.